### PR TITLE
Add support for overriding the random function used by D3 cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ export default App;
 ```
 
 ### Configuring Other Properties
-You can configure other properties of the word cloud, such as the font family, font size, randomFunction and padding, by passing them as props to the `WordCloud` component:
+You can configure other properties of the word cloud, such as the font family, font size, random number generator function and padding, by passing them as props to the `WordCloud` component:
 
 ```tsx
 import { Word, WordCloud, WordCloudProps, defaultFontSize } from "@isoterik/react-word-cloud";

--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ export default App;
 ```
 
 ### Configuring Other Properties
-You can configure other properties of the word cloud, such as the font family, font size, and padding, by passing them as props to the `WordCloud` component:
+You can configure other properties of the word cloud, such as the font family, font size, randomFunction and padding, by passing them as props to the `WordCloud` component:
 
 ```tsx
 import { Word, WordCloud, WordCloudProps, defaultFontSize } from "@isoterik/react-word-cloud";
@@ -534,6 +534,7 @@ function App() {
         transition="all .3s ease"
         padding={2}
         timeInterval={1}
+        random={Math.random}
         svgProps={{
           preserveAspectRatio: "xMidYMid slice",
         }}
@@ -683,6 +684,10 @@ export default App;
 - **rotate**: `(word: Word, index: number) => number` <br/>
   A function that returns the rotation angle (in degrees) for each word in the word cloud. The rotation angle is applied to the word's text. <br/>
   Default: `() => (~~(Math.random() * 6) - 3) * 30`
+- **random**: `() => number` <br/>
+  If specified, sets the internal random number generator, used for selecting the initial position of each word, and the clockwise/counterclockwise direction of the spiral for each word. <br/>
+  The specified function should return a number in the range [0, 1]. <br/>
+  Default: `Math.random`
 - **fill**: `string | (word: Word, index: number) => string` <br/>
   The fill color to be used for rendering the words. You can provide a string value for a single fill color or a function that returns a fill color based on the word and its index in the words array. <br/>
   Default: `(_, index) => scaleOrdinal(schemeCategory10)(String(index))`

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -24,6 +24,7 @@ export type RotateValue = Accessor<number>;
 export type FillValue = ValueOrAccessor<Property.Color>;
 export type PaddingValue = ValueOrAccessor<number>;
 export type SpiralValue = "archimedean" | "rectangular";
+export type RandomFunction = () => number;
 
 export type GradientStop = {
   offset: string;
@@ -69,4 +70,5 @@ export type WordCloudConfig = {
   fontWeight?: FontWeightValue;
   fontSize?: FontSizeValue;
   rotate?: RotateValue;
+  random?: RandomFunction;
 };

--- a/src/core/utils/compute.ts
+++ b/src/core/utils/compute.ts
@@ -17,6 +17,7 @@ export const computeWords = (
     fontWeight,
     fontSize,
     rotate,
+    random,
   } = config;
 
   return new Promise((resolve) => {
@@ -74,6 +75,10 @@ export const computeWords = (
 
     if (rotate) {
       layout.rotate((datum, index) => rotate(datum as ComputedWordData, index));
+    }
+
+    if (random) {
+      layout.random(random);
     }
 
     layout.on("word", (word) => {


### PR DESCRIPTION
Adds support for providing a custom random number generator (RNG) function to the word cloud layout.
This gives users finer control over word placement and the overall appearance of the visualization.

In our case, this was required for a project where precise rendering of words in the cloud was necessary.
Allowing users to pass an RNG function seeded for reproducible, deterministic results with the same input words could be useful in multiple usecase.

This parameter is available in other implementation such as `react-d3-cloud`

# Description

- Added a new `random` optional parameter in `WordCloudConfig` that allows overriding the random function used by D3 cloud for word placement. The new parameter is simply passed down to the layout object.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] We have tested locally in a project using our fork

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
   - No tests were added, but I can write new tests if you think it's relevant for this specific improvement
- [x] New and existing unit tests pass locally with my changes.
- [N/A] Any dependent changes have been merged and published in downstream modules.
